### PR TITLE
Ignore custom tags in check-yaml pre-commit

### DIFF
--- a/pre_commit_hooks/check_yaml.py
+++ b/pre_commit_hooks/check_yaml.py
@@ -13,8 +13,14 @@ except ImportError:  # pragma: no cover (no libyaml-dev / pypy)
 
 def check_yaml(argv=None):
     parser = argparse.ArgumentParser()
+    parser.add_argument('--ignore-tags', type=lambda s: s.split(','), default=[],
+                        help='Custom tags to ignore.')
     parser.add_argument('filenames', nargs='*', help='Yaml filenames to check.')
     args = parser.parse_args(argv)
+
+    # Ignore custom tags by returning None
+    for tag in args.ignore_tags:
+        Loader.add_constructor(tag, lambda *a, **k: None)
 
     retval = 0
     for filename in args.filenames:


### PR DESCRIPTION
Added `--ignore-tags` flag to pass a comma separated list of custom tags to ignore to `check-yaml`. This is going to be used to ignore the new `!include` tag in `metadata.yml` files.