### PR TITLE
Pin Python package versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,11 @@ setup(
     packages=find_packages(exclude=('tests*', 'testing*')),
     install_requires=[
         # quickfix to prevent pep8 conflicts
-        'flake8!=2.5.3',
-        'autopep8>=1.1',
-        'pyyaml',
-        'simplejson',
-        'six',
+        'flake8==3.3.0',
+        'autopep8==1.2.4',
+        'pyyaml==3.12',
+        'simplejson==3.10.0',
+        'six==1.10.0',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Lock in the pre-commit python package versions for consistency across all environments.